### PR TITLE
Prepare for PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,8 @@
         "post-update-cmd": [
             "sh ./vendor/bugatino/phpcs-git-pre-commit/src/setup.sh"
         ],
-        "test": "./vendor/bin/phpunit"
+        "test": "./vendor/bin/phpunit",
+        "phpcbf": "./vendor/bin/phpcbf",
+        "phpcs": "./vendor/bin/phpcs"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require-dev": {
         "phpunit/phpunit": "<9",
-        "bugatino/phpcs-git-pre-commit": "dev-master",
+        "bugatino/phpcs-git-pre-commit": "^1",
         "squizlabs/php_codesniffer": ">3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require-dev": {
-        "phpunit/phpunit": "<9",
+        "phpunit/phpunit": "<10",
         "bugatino/phpcs-git-pre-commit": "^1",
         "squizlabs/php_codesniffer": ">3"
     },

--- a/composer.json
+++ b/composer.json
@@ -9,16 +9,18 @@
             "email": "fmizzell@1312210.no-reply.drupal.org"
         }
     ],
-    "require": {},
     "require-dev": {
-        "phpunit/phpunit": "^7.4",
+        "phpunit/phpunit": "<9",
         "bugatino/phpcs-git-pre-commit": "dev-master",
-        "squizlabs/php_codesniffer": "^3.4"
+        "squizlabs/php_codesniffer": ">3"
     },
     "autoload": {
         "psr-4": {
             "Maquina\\": "src/"
         }
+    },
+    "autoload-dev": {
+        "classmap": ["test/"]
     },
     "scripts": {
         "post-install-cmd": [
@@ -26,6 +28,7 @@
         ],
         "post-update-cmd": [
             "sh ./vendor/bugatino/phpcs-git-pre-commit/src/setup.sh"
-        ]
+        ],
+        "test": "./vendor/bin/phpunit"
     }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="maquina">
+
+    <file>src</file>
+    <file>test</file>
+
+    <rule ref="PSR2">
+        <exclude name="Generic.Files.LineLength"/>
+    </rule>
+
+</ruleset>

--- a/src/StateMachine/Execution.php
+++ b/src/StateMachine/Execution.php
@@ -7,7 +7,7 @@ trait Execution
 {
     public $execution;
 
-    private $recordsData = TRUE;
+    private $recordsData = true;
 
     private function recordStateExecution($next_states)
     {
@@ -30,12 +30,13 @@ trait Execution
         array_push($this->execution, $inputs);
     }
 
-    public function startRecording() {
-        $this->recordsData = TRUE;
+    public function startRecording()
+    {
+        $this->recordsData = true;
     }
 
-    public function stopRecording() {
-        $this->recordsData = FALSE;
+    public function stopRecording()
+    {
+        $this->recordsData = false;
     }
-
 }

--- a/src/StateMachine/Machine.php
+++ b/src/StateMachine/Machine.php
@@ -126,6 +126,7 @@ class Machine implements IStateMachine, \JsonSerializable
         return $next_states;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return (object) ['currentStates' => $this->currentStates, 'halted' => $this->halted];

--- a/test/NonDeterministicStateMachineTest.php
+++ b/test/NonDeterministicStateMachineTest.php
@@ -12,7 +12,7 @@ class NonDeterministicStateMachineTest extends \PHPUnit\Framework\TestCase
    */
     private $stateMachine;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/test/StateMachineTest.php
+++ b/test/StateMachineTest.php
@@ -12,7 +12,7 @@ class StateMachineTest extends \PHPUnit\Framework\TestCase
    */
     private $stateMachine;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
This PR is part of an initiative to make sure the dependencies of [DKAN](https://github.com/GetDKAN/dkan) are compatible with PHP 8.1.

This PR does the following, as a minor refresh to ensure testability into the near future:
- Update maximum PHPUnit version to <10, which has breaking changes.
- Update `bugatino/phpcs-git-pre-commit` and `squizlabs/php_codesniffer` to less restrictive constraints, preferring stable versions.
- Adds tooling and associated Composer scripts to facilitate local development.
- Changes for PSR-2 coding standards.
- Test classes now have `setUp()` method signatures to match the superclass.
- Use of `#[\ReturnTypeWillChange]` annotation to support `jsonSerialize()` methods.